### PR TITLE
fix: stabilize training to eliminate NaN folds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-**Note: This repository is archived after experimentation. Headline result: 0.845 AUROC (focal loss transformer, 9-fold LOSO).**
+**Note: This repository is archived after experimentation. Headline result: 0.842 AUROC (focal loss transformer + grad_clip, 9/9 fold LOSO). Stabilized focal+smooth rerun pending.**
 
 ## Project Overview
 

--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -4,23 +4,27 @@ Binary per-day relapse prediction from wearable sensor data (9 patients, LOSO cr
 
 ## Results Summary
 
-| Phase | Method | Features | AUROC | AUPRC | Source |
-|-------|--------|----------|-------|-------|--------|
-| Notebook | XGBoost baseline | sleep+steps | ~0.530 | — | `notebooks/main.ipynb` |
-| Notebook | Logistic Regression | sleep+steps | ~0.580 | — | `notebooks/main.ipynb` |
-| Notebook | MLP | 24 feat | ~0.550 | — | `notebooks/main.ipynb` |
-| Notebook | Transformer (bipolar-6) | 24 feat | 0.849 | 0.794 | `notebooks/main.ipynb` |
-| Notebook | Transformer (all-9) | 24 feat | 0.793 | 0.705 | `notebooks/main.ipynb` |
-| Framework | Focal loss (d=32, exploration) | 69 feat | 0.664 | 0.545 | `docs/results/exp_focal.md` |
-| Framework | Baseline BCE (d=1024) | 69 feat | 0.808 | 0.689 | `docs/results/ablation_baseline.md` |
-| Framework | **Focal loss (γ=1, α=0.5)** | **69 feat** | **0.845** | **0.762** | `docs/results/ablation_focal.md` |
-| Framework | Focal+smooth (v1) | 69 feat | 0.838 | 0.775 | `docs/results/ablation_focal_smooth.md` |
-| Framework | Label smoothing | 69 feat | 0.833 | 0.752 | `docs/results/ablation_label_smooth.md` |
-| Framework | Training recipe sweep | 69 feat | 0.842 | — | `docs/results/ablation_recipe.md` |
-| Framework | Focal+smooth (v2, all) | 69 feat | 0.845 | 0.745 | `docs/results/ablv2_all_focal_smooth.md` |
-| Framework | Focal+smooth (v2, union) | 24 feat | 0.841 | 0.737 | `docs/results/ablv2_union_focal_smooth.md` |
+| Phase | Method | Features | AUROC | Folds | AUPRC | Source |
+|-------|--------|----------|-------|-------|-------|--------|
+| Notebook | XGBoost baseline | sleep+steps | ~0.530 | 9/9 | — | `notebooks/main.ipynb` |
+| Notebook | Logistic Regression | sleep+steps | ~0.580 | 9/9 | — | `notebooks/main.ipynb` |
+| Notebook | MLP | 24 feat | ~0.550 | 9/9 | — | `notebooks/main.ipynb` |
+| Notebook | Transformer (bipolar-6) | 24 feat | 0.849 | 6/6 | 0.794 | `notebooks/main.ipynb` |
+| Notebook | Transformer (all-9) | 24 feat | 0.793 | 9/9 | 0.705 | `notebooks/main.ipynb` |
+| Framework | Focal loss (d=32, exploration) | 69 feat | 0.664 | 9/9 | 0.545 | `docs/results/exp_focal.md` |
+| Framework | Baseline BCE (d=1024) | 69 feat | 0.824 | 8/9 | 0.689 | `docs/results/ablation_baseline.md` |
+| Framework | Focal loss (γ=1, α=0.5) | 69 feat | 0.822 | 9/9 | 0.739 | `docs/results/ablation_focal.md` |
+| Framework | Focal+smooth (v1) | 69 feat | 0.857 | 5/9 ⚠️ | 0.690 | `docs/results/ablation_focal_smooth.md` |
+| Framework | Label smoothing | 69 feat | 0.839 | 9/9 | 0.704 | `docs/results/ablation_label_smooth.md` |
+| Framework | **Training recipe (focal+gc)** | **69 feat** | **0.842** | **9/9** | **0.749** | `docs/results/ablation_recipe.md` |
+| Framework | Focal+smooth (v2, all) | 69 feat | 0.841 | 6/9 ⚠️ | 0.725 | `docs/results/ablv2_all_focal_smooth.md` |
+| Framework | Focal+smooth (v2, union) | 24 feat | 0.827 | 8/9 ⚠️ | 0.686 | `docs/results/ablv2_union_focal_smooth.md` |
+| Framework | Focal+smooth (v2 stab, all) | 69 feat | *pending* | 9/9 | *pending* | `docs/results/ablv2_all_focal_smooth_v2.md` |
+| Framework | Focal+smooth (v2 stab, union) | 24 feat | *pending* | 9/9 | *pending* | `docs/results/ablv2_union_focal_smooth_v2.md` |
 
-**Headline result: single transformer with focal loss → 0.845 AUROC** (d=1024, 3 layers, 4 heads, LOSO across 9 patients).
+⚠️ = mean computed over fewer than 9 folds (NaN folds excluded). Scientifically invalid for LOSO reporting.
+
+**Headline result: single transformer with focal loss + grad_clip → 0.842 AUROC** (d=1024, 3L, 4H, LOSO 9/9 patients). Pending stabilized focal+smooth rerun.
 
 ## Experiment Phases
 
@@ -51,28 +55,32 @@ Four transformer variants tested: bottleneck (v2), gated fusion (v3), DANN domai
 
 ### Phase 5: Ablation Study V1 (framework, 621 SLURM jobs)
 
-Systematic comparison of loss functions and regularization with d=1024, 3L, 4H:
+Systematic comparison of loss functions and regularization with d=1024, 3L, 4H. Baseline=0.824 (8/9 folds).
 
-| Technique | AUROC | Δ Baseline |
-|-----------|-------|------------|
-| **Focal loss (γ=1, α=0.5)** | **0.845** | **+0.037** |
-| Focal+smooth | 0.838 | +0.030 |
-| Label smoothing (ε=0.2) | 0.833 | +0.025 |
-| Stochastic depth (p=0.3) | 0.820 | +0.012 |
-| Weight decay (λ=1e-3) | 0.812 | +0.004 |
-| RoPE | 0.756 | −0.052 |
+| Technique | AUROC | Folds | Δ Baseline |
+|-----------|-------|-------|------------|
+| Focal+smooth | 0.857 | 5/9 ⚠️ | — |
+| Label smoothing (ε=0.05) | 0.839 | 9/9 | +0.015 |
+| Stochastic depth (p=0.3) | 0.824 | 8/9 | +0.000 |
+| Focal loss (γ=1, α=0.5) | 0.822 | 9/9 | −0.002 |
+| Weight decay (λ=1e-3) | 0.811 | 8/9 | −0.013 |
+| RoPE | 0.758 | 8/9 | −0.066 |
 
 ### Phase 6: Training Recipe Sweep (framework, 216 SLURM jobs)
 
-Tested optimizer (Adam/AdamW), LR scheduling (none/cosine), gradient clipping, warmup. **No recipe beat the baseline 0.845.** Cosine schedule actively hurt performance.
+Tested optimizer (Adam/AdamW), LR scheduling (none/cosine), gradient clipping, warmup. Best: adam + fixed LR + grad_clip=1.0 → 0.842 (9/9 folds). Cosine schedule actively hurt performance.
 
 ### Phase 7: Ablation V2 (framework, 810 SLURM jobs)
 
-Re-ran all ablations with both union (24) and all (69) feature sets. Confirmed feature set gap is small (~0.004 AUROC). Best config: focal+smooth at 0.845 AUROC.
+Re-ran all ablations with both union (24) and all (69) feature sets. "All" feature set configs are fully valid (9/9 folds) except focal+smooth (6/9). Union configs have sporadic NaN folds.
+
+### Phase 8: Stabilized Focal+Smooth Rerun (pending)
+
+Added training stabilization (NaN recovery, checkpoint guards, auto grad_clip for focal+smooth). New configs: `ablv2_all_focal_smooth_v2`, `ablv2_union_focal_smooth_v2` (grad_clip=1.0, AdamW). Same sweep grid as original. To be submitted to SLURM.
 
 ## Key Findings
 
-1. **Loss function > regularization**: focal loss (+0.037) and label smoothing (+0.025) dominate; architectural regularization (stochastic depth, weight decay) give marginal gains
+1. **Loss function > regularization**: label smoothing (+0.015) helps; focal loss alone is neutral vs baseline but combined with grad clipping gives best result (0.842)
 2. **Mild focal focus is optimal**: γ=1.0 >> γ=2.0 or 3.0 — with only 9 patients and ~20 relapse days per fold, aggressive down-weighting loses gradient signal
 3. **RoPE hurts short sequences**: 7-day windows are too short for relative position bias to help
 4. **Bipolar subset is stronger**: bipolar-only (6 patients) AUROC 0.849 vs all-9 at 0.793 — non-bipolar patients (P1 brief psychotic, P2 schizophreniform, P7 schizophrenia) are harder
@@ -81,28 +89,30 @@ Re-ran all ablations with both union (24) and all (69) feature sets. Confirmed f
 
 ## Negative Results
 
-- **Training recipe sweep found nothing**: cosine schedule, AdamW, gradient clipping, warmup — none improved over baseline Adam + fixed LR
+- **Recipe sweep produced best valid result**: adam + grad_clip=1.0 → 0.842 (9/9), the only fully-valid result above 0.84
 - **Cosine schedule hurts**: counter-intuitively, fixed LR oscillation aids best-epoch checkpoint selection
-- **AdamW is unstable**: 11% NaN rate without gradient clipping
+- **NaN folds are widespread**: V1 baseline, stoch_depth, weight_decay, rope all have 1 NaN fold; focal+smooth has 4-5 NaN folds. Training instability without gradient clipping
 - **Ensemble methods** (0.912–0.938): not credible with 9 patients; removed from repository
 - **Unsupervised pretraining** (BumbleBee autoencoder): 0.48 AUROC — worse than random when used alone, and fusion with supervised features (0.72) hurt vs supervised-only
 
 ## Reproduction
 
-### Headline result (0.845 AUROC)
+### Headline result (0.842 AUROC, pending stabilized rerun)
 
 ```bash
 # Preprocess data
 python scripts/preprocess_data.py
 
-# Run ablation with focal loss
-bash scripts/run.sh -n ablation_focal
+# Best fully-valid result: training recipe (focal + grad_clip)
+bash scripts/submit_slurm.sh -n ablation_recipe
 
-# Or submit to SLURM
-bash scripts/submit_slurm.sh -n ablation_focal
+# Stabilized focal+smooth rerun (pending)
+bash scripts/submit_slurm.sh -n ablv2_all_focal_smooth_v2
+bash scripts/submit_slurm.sh -n ablv2_union_focal_smooth_v2
 ```
 
-Config: `configs/ablation_focal.json` — sweeps γ ∈ {1.0, 2.0, 3.0} × α ∈ {0.3, 0.5, 0.7} with 9-fold LOSO.
+Config: `configs/ablation_recipe.json` — focal loss (γ=1.0, α=0.5) + grad_clip=1.0, 9-fold LOSO.
+Stabilized: `configs/ablv2_all_focal_smooth_v2.json` — focal + label smoothing + grad_clip=1.0 + AdamW.
 
 ### Notebook results
 

--- a/configs/ablv2_all_focal_smooth_v2.json
+++ b/configs/ablv2_all_focal_smooth_v2.json
@@ -1,0 +1,43 @@
+{
+    "_description": "Ablation v2 — All focal + label smoothing (stabilized: grad_clip + adamw). 9 folds x 2 gamma x 3 alpha x 4 eps = 216 jobs.",
+    "method": "feature_exp",
+    "fold": [0, 1, 2, 3, 4, 5, 6, 7, 8],
+    "feature_set": "all",
+    "d_model": 1024,
+    "n_layers": 3,
+    "dropout": 0.3,
+    "nhead": 4,
+    "seq_len": 7,
+    "batch_size": 32,
+    "lr": 1e-3,
+    "n_epochs": 80,
+    "seed": 42,
+    "data_path": "data/processed/patient_data_export_all9.pkl",
+    "loss_type": "focal",
+    "focal_gamma": [0.5, 1.0],
+    "focal_alpha": [0.3, 0.5, 0.7],
+    "label_smoothing": [0.1, 0.15, 0.2, 0.25],
+    "optimizer": "adamw",
+    "grad_clip": 1.0,
+    "executor": {
+        "exec_name": "ablation",
+        "output_dir": "outputs/ablations_v2",
+        "log_dir": "outputs/ablations_v2/logs"
+    },
+    "slurm": {
+        "cores": 4,
+        "nodes": 1,
+        "time": "0-04:00",
+        "memory": "4G",
+        "partition": "gpunodes",
+        "account": "",
+        "email": "Khashayar1924@gmail.com",
+        "email_type": "END,FAIL",
+        "log_dir": "outputs/slurm_logs",
+        "job_name": "a_fs2",
+        "exclude": "gpunode13",
+        "constraint": "",
+        "gres": "gpu:1",
+        "julia_path": ""
+    }
+}

--- a/configs/ablv2_union_focal_smooth_v2.json
+++ b/configs/ablv2_union_focal_smooth_v2.json
@@ -1,0 +1,43 @@
+{
+    "_description": "Ablation v2 — Union focal + label smoothing (stabilized: grad_clip + adamw). 9 folds x 2 gamma x 3 alpha x 4 eps = 216 jobs.",
+    "method": "feature_exp",
+    "fold": [0, 1, 2, 3, 4, 5, 6, 7, 8],
+    "feature_set": "union",
+    "d_model": 1024,
+    "n_layers": 3,
+    "dropout": 0.3,
+    "nhead": 4,
+    "seq_len": 7,
+    "batch_size": 32,
+    "lr": 1e-3,
+    "n_epochs": 80,
+    "seed": 42,
+    "data_path": "data/processed/patient_data_export_all9.pkl",
+    "loss_type": "focal",
+    "focal_gamma": [0.5, 1.0],
+    "focal_alpha": [0.3, 0.5, 0.7],
+    "label_smoothing": [0.1, 0.15, 0.2, 0.25],
+    "optimizer": "adamw",
+    "grad_clip": 1.0,
+    "executor": {
+        "exec_name": "ablation",
+        "output_dir": "outputs/ablations_v2",
+        "log_dir": "outputs/ablations_v2/logs"
+    },
+    "slurm": {
+        "cores": 4,
+        "nodes": 1,
+        "time": "0-04:00",
+        "memory": "4G",
+        "partition": "gpunodes",
+        "account": "",
+        "email": "Khashayar1924@gmail.com",
+        "email_type": "END,FAIL",
+        "log_dir": "outputs/slurm_logs",
+        "job_name": "u_fs2",
+        "exclude": "gpunode13",
+        "constraint": "",
+        "gres": "gpu:1",
+        "julia_path": ""
+    }
+}

--- a/src/ablation.py
+++ b/src/ablation.py
@@ -539,7 +539,7 @@ def train_fold(
         scheduler = torch.optim.lr_scheduler.SequentialLR(
             opt, [warmup_sched, cosine_sched], milestones=[warmup_epochs])
 
-    best_auroc, best_state, best_epoch = -1.0, None, -1
+    best_auroc, best_state, best_opt_state, best_epoch = -1.0, None, None, -1
     history = []
 
     for epoch in range(n_epochs):
@@ -563,18 +563,19 @@ def train_fold(
             ep_loss += loss.item() * len(Xb)
         ep_loss /= max(n_train_windows, 1)
 
-        # NaN loss recovery: restore best checkpoint and halve lr
-        if math.isnan(ep_loss):
+        # Non-finite loss recovery: restore best checkpoint + optimizer and halve lr
+        if not math.isfinite(ep_loss):
             if best_state is not None:
                 model.load_state_dict(best_state)
                 model.to(device)
+                opt.load_state_dict(best_opt_state)
                 for pg in opt.param_groups:
                     pg["lr"] *= 0.5
                 new_lr = opt.param_groups[0]["lr"]
-                print(f"  NaN loss at epoch {epoch+1}, recovered from epoch {best_epoch}, lr→{new_lr:.1e}")
+                print(f"  Non-finite loss at epoch {epoch+1}, recovered from epoch {best_epoch}, lr→{new_lr:.1e}")
                 continue
             else:
-                print(f"  NaN loss at epoch {epoch+1}, no checkpoint to recover from")
+                print(f"  Non-finite loss at epoch {epoch+1}, no checkpoint to recover from")
                 break
 
         if scheduler is not None:
@@ -586,10 +587,12 @@ def train_fold(
                 model(X_te_t.to(device), src_key_padding_mask=m_te_t.to(device))
             ).cpu().numpy()
 
-        # Guard: don't checkpoint if model weights are NaN
-        has_nan_params = any(torch.isnan(p).any() for p in model.parameters())
-        if has_nan_params:
-            print(f"  NaN in model params at epoch {epoch+1}, skipping checkpoint")
+        # Guard: don't checkpoint if params or predictions are non-finite
+        params_ok = all(torch.isfinite(p).all() for p in model.parameters())
+        probs_ok = bool(np.isfinite(probs).all())
+        if not params_ok or not probs_ok:
+            reason = "params" if not params_ok else "predictions"
+            print(f"  Non-finite {reason} at epoch {epoch+1}, skipping checkpoint")
             ep_auroc = float("nan")
         else:
             try:
@@ -597,9 +600,10 @@ def train_fold(
             except Exception:
                 ep_auroc = 0.5
 
-        if not math.isnan(ep_auroc) and ep_auroc > best_auroc:
+        if math.isfinite(ep_auroc) and ep_auroc > best_auroc:
             best_auroc = ep_auroc
             best_state = copy.deepcopy(model.state_dict())
+            best_opt_state = copy.deepcopy(opt.state_dict())
             best_epoch = epoch + 1
 
         history.append({
@@ -621,7 +625,7 @@ def train_fold(
             "best_epoch": -1,
             "n_test_windows": n_test_windows, "n_test_relapse": n_test_relapse,
             "n_train_windows": n_train_windows, "n_train_relapse": n_train_relapse,
-            "model_params": n_params,
+            "model_params": n_params, "effective_grad_clip": grad_clip,
             "y_true": y_te.tolist(), "y_score": [],
             "history": history, "error": "training diverged (NaN loss)",
         }
@@ -634,17 +638,17 @@ def train_fold(
             model(X_te_t.to(device), src_key_padding_mask=m_te_t.to(device))
         ).cpu().numpy()
 
-    # Handle NaN in predictions
-    if np.any(np.isnan(final_probs)):
+    # Handle non-finite predictions
+    if not np.isfinite(final_probs).all():
         return {
             "auroc": float("nan"), "auprc": float("nan"),
             "f1": 0.0, "precision": 0.0, "recall": 0.0, "accuracy": 0.0,
             "best_epoch": best_epoch,
             "n_test_windows": n_test_windows, "n_test_relapse": n_test_relapse,
             "n_train_windows": n_train_windows, "n_train_relapse": n_train_relapse,
-            "model_params": n_params,
+            "model_params": n_params, "effective_grad_clip": grad_clip,
             "y_true": y_te.tolist(), "y_score": [],
-            "history": history, "error": "NaN in predictions",
+            "history": history, "error": "non-finite predictions",
         }
 
     auroc = float(roc_auc_score(y_te, final_probs))
@@ -664,6 +668,7 @@ def train_fold(
         "n_train_windows": n_train_windows,
         "n_train_relapse": n_train_relapse,
         "model_params": n_params,
+        "effective_grad_clip": grad_clip,
         "y_true": y_te.tolist(),
         "y_score": final_probs.tolist(),
         "history": history,
@@ -837,7 +842,7 @@ def main(
             "optimizer": optimizer,
             "lr_schedule": lr_schedule,
             "warmup_epochs": warmup_epochs,
-            "grad_clip": grad_clip,
+            "grad_clip": result.get("effective_grad_clip", grad_clip),
         },
         "n_features": len(feature_cols),
         "feature_cols": feature_cols,

--- a/src/ablation.py
+++ b/src/ablation.py
@@ -519,6 +519,12 @@ def train_fold(
     else:
         crit = nn.BCEWithLogitsLoss()
 
+    # Auto-enable grad clipping when focal + label smoothing are combined
+    # to prevent gradient explosion from their interaction
+    if loss_type == "focal" and label_smoothing > 0 and grad_clip == 0:
+        grad_clip = 1.0
+        print(f"  Auto-enabled grad_clip=1.0 for focal+smooth stability")
+
     if optimizer == "adamw":
         opt = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=weight_decay)
     else:
@@ -557,6 +563,20 @@ def train_fold(
             ep_loss += loss.item() * len(Xb)
         ep_loss /= max(n_train_windows, 1)
 
+        # NaN loss recovery: restore best checkpoint and halve lr
+        if math.isnan(ep_loss):
+            if best_state is not None:
+                model.load_state_dict(best_state)
+                model.to(device)
+                for pg in opt.param_groups:
+                    pg["lr"] *= 0.5
+                new_lr = opt.param_groups[0]["lr"]
+                print(f"  NaN loss at epoch {epoch+1}, recovered from epoch {best_epoch}, lr→{new_lr:.1e}")
+                continue
+            else:
+                print(f"  NaN loss at epoch {epoch+1}, no checkpoint to recover from")
+                break
+
         if scheduler is not None:
             scheduler.step()
 
@@ -565,12 +585,19 @@ def train_fold(
             probs = torch.sigmoid(
                 model(X_te_t.to(device), src_key_padding_mask=m_te_t.to(device))
             ).cpu().numpy()
-        try:
-            ep_auroc = roc_auc_score(y_te, probs)
-        except Exception:
-            ep_auroc = 0.5
 
-        if ep_auroc > best_auroc:
+        # Guard: don't checkpoint if model weights are NaN
+        has_nan_params = any(torch.isnan(p).any() for p in model.parameters())
+        if has_nan_params:
+            print(f"  NaN in model params at epoch {epoch+1}, skipping checkpoint")
+            ep_auroc = float("nan")
+        else:
+            try:
+                ep_auroc = roc_auc_score(y_te, probs)
+            except Exception:
+                ep_auroc = 0.5
+
+        if not math.isnan(ep_auroc) and ep_auroc > best_auroc:
             best_auroc = ep_auroc
             best_state = copy.deepcopy(model.state_dict())
             best_epoch = epoch + 1
@@ -582,8 +609,9 @@ def train_fold(
         })
 
         if (epoch + 1) % 20 == 0:
+            auroc_str = f"{ep_auroc:.4f}" if not math.isnan(ep_auroc) else "NaN"
             print(f"  Epoch {epoch+1:3d}/{n_epochs}  loss={ep_loss:.4f}  "
-                  f"AUROC={ep_auroc:.4f}  best={best_auroc:.4f}")
+                  f"AUROC={auroc_str}  best={best_auroc:.4f}")
 
     # Guard against NaN divergence (no valid checkpoint saved)
     if best_state is None:


### PR DESCRIPTION
## Summary

- NaN folds in focal+smooth configs (P1/P3/P7) caused by gradient explosion — reported 0.841 AUROC was over 6/9 patients, not 9
- Added training stabilization: auto grad_clip for focal+smooth, NaN loss recovery with lr halving, checkpoint NaN guard
- Created stabilized configs (`ablv2_all_focal_smooth_v2`, `ablv2_union_focal_smooth_v2`) with grad_clip=1.0 + AdamW
- Corrected inflated AUROC numbers in EXPERIMENTS.md (old headline 0.845 → honest 0.842 from 9/9 folds)

## Verification

- `src/ablation.py` imports cleanly
- Config validation: both new configs produce 216 job combos with correct params
- **Local fold test**: P1 (previously NaN) now produces AUROC=0.894 with stabilized config

## Next steps after merge

```bash
bash scripts/submit_slurm.sh -n ablv2_all_focal_smooth_v2    # 216 jobs
bash scripts/submit_slurm.sh -n ablv2_union_focal_smooth_v2   # 216 jobs
python scripts/generate_docs.py                                # after completion
```

- [ ] Submit stabilized configs to SLURM
- [ ] Verify all 9 folds valid in output docs
- [ ] Update EXPERIMENTS.md *pending* rows with actual numbers
- [ ] Update CLAUDE.md headline with final number

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated experiment results, reported metrics, fold counts and status notes; added pending/stabilized rerun indicators.

* **New Features**
  * Added new ablation experiment configurations for focal+label-smoothing stability sweeps.

* **Bug Fixes**
  * Improved training stability and automatic recovery from non-finite losses; automatic grad clipping for focal+label-smoothing runs; clearer handling and reporting when validation metrics are NaN.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->